### PR TITLE
Default NOTION_{AUTH_TOKEN,TEST_AREA} during preflight

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,11 @@
 {
     "version": "2.0.0",
-
+    "options": {
+        "env": {
+            "NOTION_AUTH_TOKEN": "",
+            "NOTION_TEST_AREA": "250662d9783d483cb131341ed479f96c",
+        }
+    },
     "tasks": [
         {
             "label": "Build Local Environment",


### PR DESCRIPTION
Closes #44:

- If `cassettes` are used: the added envs will allow `preflight` to correctly run all tests that would be skipped otherwise. Tests will still be skipped if triggered from [Test Explorer sidebar](https://code.visualstudio.com/docs/python/testing#_configure-tests) (envs would need to be added to launch.json)
- If `cassettes` are not used/being generated: the envs should be set to a valid value. If tests are executed with `NOTION_TEST_AREA != 250662d9783d483cb131341ed479f96c`, the value should be updated in `tasks.json`.