### PR TITLE
Remove is_emoji which is now in the emoji lib itself

### DIFF
--- a/examples/props.py
+++ b/examples/props.py
@@ -31,7 +31,7 @@ print(f"{page.Title} => {page.url}")
 
 # print all current properties on the page...
 for name, value in page.properties.items():
-    # use the endpoint to retrive the full property data
+    # use the endpoint to retrieve the full property data
     prop = notion.pages.properties.retrieve(page_id, value.id)
 
     print(f"{name} [{prop.id}] => {prop}")

--- a/src/notional/blocks.py
+++ b/src/notional/blocks.py
@@ -143,7 +143,7 @@ class TextBlock(Block, ABC):
 
     @property
     def __text__(self):
-        """Provide short-hand access to the nested text content in this block."""
+        """Provide shorthand access to the nested text content in this block."""
 
         return self("rich_text")
 

--- a/src/notional/orm.py
+++ b/src/notional/orm.py
@@ -7,11 +7,11 @@ in Notional: `Property()` and `connected_page()`.
 import logging
 from typing import Union
 
-from emoji import emojize
+from emoji import emojize, is_emoji
 
 from .blocks import Page
 from .schema import PropertyObject, RichText
-from .text import is_emoji, make_safe_python_name
+from .text import make_safe_python_name
 from .types import DatabaseRef, EmojiObject, ExternalFile, PropertyValue
 
 logger = logging.getLogger(__name__)

--- a/src/notional/session.py
+++ b/src/notional/session.py
@@ -374,7 +374,7 @@ class PagesEndpoint(Endpoint):
 
         # https://developers.notion.com/reference/retrieve-a-page-property
         def retrieve(self, page_id, property_id):
-            """Return the Property on a specific page Page with the given ID."""
+            """Return the Property on a specific Page with the given ID."""
 
             logger.info("Retrieving property :: %s [%s]", property_id, page_id)
 
@@ -496,7 +496,7 @@ class PagesEndpoint(Endpoint):
         return page.refresh(**data)
 
     def set(self, page, cover=False, icon=False, archived=None):
-        """Set specific page attributes (such as cover, icon, etc) on the server.
+        """Set specific page attributes (such as cover, icon, etc.) on the server.
 
         `page` may be any suitable `PageRef` type.
 

--- a/src/notional/text.py
+++ b/src/notional/text.py
@@ -5,8 +5,6 @@ from copy import deepcopy
 from enum import Enum
 from typing import Optional
 
-from emoji import EMOJI_DATA
-
 from .core import GenericObject, TypedObject
 
 # this might be a place to capture other utilities for working with markdown, text
@@ -47,11 +45,6 @@ def rich_text(*text):
 def markdown(*rtf):
     """Return text as markdown from the list of RichText objects."""
     return "".join(str(text) for text in rtf if text)
-
-
-def is_emoji(text):
-    """Check if text is a single emoji."""
-    return text in EMOJI_DATA
 
 
 def chunky(text, length=MAX_TEXT_OBJECT_SIZE):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,7 +1,7 @@
 """Unit tests for text types in Notional."""
 
 from notional import blocks
-from notional.text import Annotations, TextObject, is_emoji, markdown, plain_text
+from notional.text import Annotations, TextObject, markdown, plain_text
 
 
 def confirm_block_markdown(cls, plain, md):
@@ -108,13 +108,3 @@ def test_code_word():
 
     assert plain_text(text) == "keyword"
     assert markdown(text) == "`keyword`"
-
-
-def test_is_emoji():
-    """Test if is_emoji detects single emoji."""
-    assert is_emoji("🍟")
-    assert not is_emoji("no emoji")
-    assert not is_emoji("I love 🍟")
-    assert not is_emoji("🍟🍟")
-    assert not is_emoji("🍟 is my favourite")
-    assert not is_emoji("🍟🍔")


### PR DESCRIPTION
This PR removes the `is_emoji` function which is now included directly in `emoji`. It also fixes a few typos that PyCharm found.