### PR TITLE
Added support for append(.. , after=block)

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -379,3 +379,22 @@ def test_synced_block(notion):
 
     assert isinstance(sync_block, blocks.SyncedBlock)
     assert not sync_block.IsOriginal
+
+
+def test_append_block_after(notion, test_area):
+    first_block = blocks.Paragraph["first"]
+    second_block = blocks.Paragraph["second"]
+    notion.blocks.children.append(test_area, first_block, second_block)
+
+    added_blocks = list(notion.blocks.children.list(test_area))
+    assert added_blocks == [first_block, second_block]
+
+    inserted_block = blocks.Paragraph["inserted"]
+    notion.blocks.children.append(test_area, inserted_block, after=first_block)
+
+    added_blocks = list(notion.blocks.children.list(test_area))
+    assert added_blocks == [first_block, inserted_block, second_block]
+
+    notion.blocks.delete(first_block)
+    notion.blocks.delete(inserted_block)
+    notion.blocks.delete(second_block)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -381,6 +381,7 @@ def test_synced_block(notion):
     assert not sync_block.IsOriginal
 
 
+@pytest.mark.vcr()
 def test_append_block_after(notion, test_area):
     first_block = blocks.Paragraph["first"]
     second_block = blocks.Paragraph["second"]


### PR DESCRIPTION
After keyword is already supported in the `.append()` call, I am just passing it from the `BlocksEndpoint.append()`.

The only thing I wasn't so sure about was the `if len(blocks) == len(data["results"])` condition, but since the for loop is iterating over the newly added blocks (`len(blocks)`) anyway, it works as expected.

https://developers.notion.com/reference/patch-block-children